### PR TITLE
Update favicon to match navbar icon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -2,18 +2,15 @@
   <!-- Background -->
   <rect width="32" height="32" rx="8" fill="#ffffff"/>
   
-  <!-- Stylized S -->
-  <path d="M8 12C8 8 12 6 16 6C20 6 24 8 24 12C24 14 22 16 20 16C18 16 16 14 16 12" 
-        fill="none" 
-        stroke="#2563eb" 
-        stroke-width="2.5" 
-        stroke-linecap="round" 
-        stroke-linejoin="round"/>
+  <!-- Door frame -->
+  <rect x="8" y="6" width="16" height="20" rx="2" fill="none" stroke="#2563eb" stroke-width="2"/>
   
-  <path d="M24 20C24 24 20 26 16 26C12 26 8 24 8 20C8 18 10 16 12 16C14 16 16 18 16 20" 
-        fill="none" 
-        stroke="#2563eb" 
-        stroke-width="2.5" 
-        stroke-linecap="round" 
-        stroke-linejoin="round"/>
+  <!-- Door panel -->
+  <rect x="10" y="8" width="12" height="16" rx="1" fill="#f8fafc" stroke="#2563eb" stroke-width="1.5"/>
+  
+  <!-- Door handle -->
+  <circle cx="18" cy="16" r="1.5" fill="#2563eb"/>
+  
+  <!-- Door opening indicator (small gap) -->
+  <rect x="9" y="7" width="1" height="18" fill="#2563eb"/>
 </svg>


### PR DESCRIPTION
Update the favicon to a door icon to align with the 'doors' section in the navigation bar for visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-2643dc6b-7c4f-42d4-b0c6-c1c1e1bc80c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2643dc6b-7c4f-42d4-b0c6-c1c1e1bc80c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

