### PR TITLE
Match events heading style

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -188,7 +188,7 @@
             <div class="container">
                 <section class="events-section" aria-label="Events">
                     <header class="section-header">
-                        <h2><i class="fas fa-list" aria-hidden="true"></i> Events</h2>
+                        <h1><i class="fas fa-history" aria-hidden="true"></i> Events</h1>
                         <div class="event-controls">
                             <div class="stream-status">
                                 <span class="status-indicator" id="eventStreamStatus">


### PR DESCRIPTION
Update the events section heading to match the styling and structure of other sections.

The heading now uses an `<h1>` tag and a more appropriate `fa-history` icon for consistency with the rest of the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-e48ea337-2507-4371-8fc0-44b8b679553d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e48ea337-2507-4371-8fc0-44b8b679553d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

