### PR TITLE
Investigate post-deployment crash

### DIFF
--- a/routes/doors.js
+++ b/routes/doors.js
@@ -126,7 +126,7 @@ router.post('/heartbeat', validateHeartbeat, asyncHandler(async (req, res) => {
       message: 'Failed to process heartbeat'
     });
   }
-});
+}));
 
 // Get all doors (admin only)
 router.get('/', authenticate, requireAdmin, validatePagination, async (req, res) => {


### PR DESCRIPTION
Fix `SyntaxError` in `routes/doors.js` by adding a missing closing parenthesis for the `asyncHandler` wrapper.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9686c42-a18e-4f06-8eb1-67825f1ac59f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9686c42-a18e-4f06-8eb1-67825f1ac59f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

